### PR TITLE
Preparation for release 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,15 @@
 
     <groupId>io.patriot-framework</groupId>
     <artifactId>kubernetes-network-simulator</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+        <io.patriot-framework.version>5.0.0-SNAPSHOT</io.patriot-framework.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
         <skip-tests>true</skip-tests>
     </properties>
 
@@ -19,50 +22,75 @@
         <dependency>
             <groupId>io.patriot-framework</groupId>
             <artifactId>generator</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-            <version>5.2.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>${io.patriot-framework.version}</version>
         </dependency>
         <dependency>
             <groupId>io.patriot-framework</groupId>
             <artifactId>patriot-api</artifactId>
-            <version>2.0.0</version>
+            <version>${io.patriot-framework.version}</version>
         </dependency>
-
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${com.fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${com.fasterxml.jackson.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.4.0</version>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.12.12</version>
+            <version>3.12.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20140107</version>
+            <version>20230618</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.9.1</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- newer version have different api -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>5.4.2</version>
+        </dependency>
+
+        <!-- resolve vulnerabilities form dependencies of kubernetes-client -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${com.fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${com.fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.23.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/controller/KubernetesControllerTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/controller/KubernetesControllerTest.java
@@ -1,5 +1,6 @@
 package io.patriot_framework.network_simulator.kubernetes.controller;
 
+import io.patriot_framework.generator.Data;
 import io.patriot_framework.generator.controll.client.CoapControlClient;
 import io.patriot_framework.generator.dataFeed.ConstantDataFeed;
 import io.patriot_framework.generator.dataFeed.DataFeed;
@@ -16,17 +17,23 @@ import io.patriot_framework.network_simulator.kubernetes.device.DataGenerator;
 import io.patriot_framework.network_simulator.kubernetes.device.KubeDevice;
 import io.patriot_framework.network_simulator.kubernetes.exceptions.KubernetesSimulationException;
 import io.patriot_framework.network_simulator.kubernetes.network.KubeNetwork;
-import io.patriot_framework.network_simulator.kubernetes.utils.RequestBin;
+import io.patriot_framework.network_simulator.kubernetes.utils.request_bin.RBImplRequestBin;
 import io.patriot_framework.network_simulator.kubernetes.utils.Utils;
+import io.patriot_framework.network_simulator.kubernetes.utils.request_bin.RequestBin;
+import io.patriot_framework.network_simulator.kubernetes.utils.request_bin.RequestBinFactory;
+import io.patriot_framework.network_simulator.kubernetes.utils.request_bin.RequestBinFactoryImpl;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KubernetesControllerTest extends AbstractControllerTest {
     private static final String NETWORK_NAME = "kubernetes-controller-network";
+    private static final RequestBinFactory requestBinFactory = new RequestBinFactoryImpl();
 
 
     @Test
@@ -54,7 +61,7 @@ public class KubernetesControllerTest extends AbstractControllerTest {
 
     @Test
     public void createActiveDataGeneratorDeviceTest() throws IOException, InterruptedException, KubernetesSimulationException {
-        RequestBin requestBin = new RequestBin();
+        RequestBin requestBin = requestBinFactory.create();
 
         KubeNetwork network = new KubeNetwork("network123");
         controller.createNetwork(network);
@@ -62,6 +69,7 @@ public class KubernetesControllerTest extends AbstractControllerTest {
         DataFeed df = new NormalDistVariateDataFeed(18, 2);
         Device temperature = new Thermometer("thermometer", df);
         NetworkAdapter na = new Rest(requestBin.url(), new JSONWrapper());
+
         temperature.setNetworkAdapter(na);
 
         DataFeed tf = new ConstantDataFeed(2000);
@@ -72,7 +80,6 @@ public class KubernetesControllerTest extends AbstractControllerTest {
         kubeDevice.getDeviceConfig().setEnableInternet(true);
 
         controller.deployDevice(kubeDevice);
-
 
         Thread.sleep(60000);
 

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/controller/NetworkRestrictionTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/controller/NetworkRestrictionTest.java
@@ -29,7 +29,6 @@ public class NetworkRestrictionTest extends AbstractControllerTest {
     public void setupTest() throws KubernetesSimulationException {
         deviceNetwork = new KubeNetwork("my-nice-network");
         controller.createNetwork(deviceNetwork);
-
         DataFeed dataFeed = new NormalDistVariateDataFeed(18, 2);
         Device device = new Thermometer("simpleThermometer", dataFeed);
 

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RBImplRequestBin.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RBImplRequestBin.java
@@ -1,6 +1,7 @@
-package io.patriot_framework.network_simulator.kubernetes.utils;
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
 
 import com.google.gson.Gson;
+import io.patriot_framework.network_simulator.kubernetes.utils.HttpClient;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -17,16 +18,16 @@ import java.util.Objects;
 /**
  * Class representing request bin object of https://requestbin.io website.
  * Request bin is used for webhook testing. It provides a service
- * where we can send HTTP requests, the requests are stored and we can collect them afterwards.
+ * where we can send HTTP requests, the requests are stored, and we can collect them afterwards.
  */
-public class RequestBin {
+public class RBImplRequestBin implements RequestBin {
     private static final String REQUEST_BIN_URL = "https://requestbin.io";
     private static final String API_SUFFIX = "/api/v1/bins";
     private final Gson gson = new Gson();
     OkHttpClient client = new OkHttpClient.Builder().build();
-    private String name;
+    private final String name;
 
-    public RequestBin() throws IOException {
+    public RBImplRequestBin() throws IOException {
         this.name = createRequestBinInstance();
     }
 
@@ -35,11 +36,6 @@ public class RequestBin {
     }
 
 
-    /**
-     * Returns list of received webhooks
-     *
-     * @return List of RequestBinResults
-     */
     public List<RequestBinResult> getLatestResults() throws IOException {
         Request request = new Request
                 .Builder()
@@ -68,12 +64,11 @@ public class RequestBin {
             ResponseBody responseBody = response.body();
             RequestBinEntity entity =
                     gson.fromJson(Objects.requireNonNull(responseBody).string(), RequestBinEntity.class);
-
             return entity.getName();
         }
     }
 
-    private class RequestBinEntity {
+    private static class RequestBinEntity {
         private String name;
 
         public RequestBinEntity(String name) {
@@ -88,5 +83,4 @@ public class RequestBin {
             this.name = name;
         }
     }
-
 }

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RBImplWebHook.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RBImplWebHook.java
@@ -1,0 +1,107 @@
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.patriot_framework.network_simulator.kubernetes.utils.HttpClient;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Class representing request bin object of https://webhook.site website.
+ * It provides a service where we can send HTTP requests, the requests
+ * are stored, and we can collect them afterwards.
+ */
+public class RBImplWebHook implements RequestBin {
+    private static final String REQUEST_BIN_URL = "https://webhook.site";
+    private static final String TOKEN_SUFFIX = "/token";
+    private final String uuid;
+    OkHttpClient client = new OkHttpClient.Builder().build();
+    private final Gson gson = new Gson();
+
+    public RBImplWebHook() throws IOException {
+        Request request = new Request
+                .Builder()
+                .post(RequestBody.create(HttpClient.JSON, ""))
+                .url(REQUEST_BIN_URL + TOKEN_SUFFIX)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            ResponseBody responseBody = response.body();
+
+            RBImplWebHook.Token token =
+                    gson.fromJson(Objects.requireNonNull(responseBody).string(), RBImplWebHook.Token.class);
+            this.uuid = token.getUuid();
+        }
+    }
+
+    public String url() {
+        return String.format("%s/%s", REQUEST_BIN_URL, uuid);
+    }
+
+    public List<RequestBinResult> getLatestResults() throws IOException {
+        Request request = new Request
+                .Builder()
+                .get()
+                .url(String.format("%s%s/%s/requests", REQUEST_BIN_URL, TOKEN_SUFFIX, uuid))
+                .build();
+        String responseData;
+        try (Response response = client.newCall(request).execute()) {
+            responseData = Objects.requireNonNull(response.body()).string();
+        }
+        JsonObject jsonObject = gson.fromJson(responseData, JsonObject.class);
+        MyRequestBinResult[] results =
+                gson.fromJson(jsonObject.getAsJsonArray("data"), MyRequestBinResult[].class);
+
+        RequestBinResult[] mappedResults = Stream.of(results)
+                .map(o -> new RequestBinResult(o.getContent()))
+                .toArray(RequestBinResult[]::new);
+
+        return new ArrayList<>(Arrays.asList(mappedResults));
+    }
+
+    private static class Token {
+        private String uuid;
+
+        public Token(String name) {
+            this.uuid = name;
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public void setUuid(String uuid) {
+            this.uuid = uuid;
+        }
+    }
+
+    /**
+     * Represents once object retrieved from webhook.site.
+     */
+    private static class MyRequestBinResult {
+        private String content;
+
+        /**
+         * Constructor with body parameter
+         *
+         * @param content content from retrieved data
+         */
+        public MyRequestBinResult(String content) {
+            this.content = content;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setBody(String content) {
+            this.content = content;
+        }
+    }
+}

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBin.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBin.java
@@ -1,0 +1,15 @@
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface RequestBin {
+    public String url();
+
+    /**
+     * Returns list of received webhooks
+     *
+     * @return List of RequestBinResults
+     */
+    public List<RequestBinResult> getLatestResults() throws IOException;
+}

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinFactory.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinFactory.java
@@ -1,0 +1,8 @@
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
+
+import org.apache.commons.lang3.NotImplementedException;
+import java.io.IOException;
+
+public interface RequestBinFactory {
+    RequestBin create() throws IOException, NotImplementedException;
+}

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinFactoryImpl.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinFactoryImpl.java
@@ -1,0 +1,29 @@
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
+
+public class RequestBinFactoryImpl implements RequestBinFactory {
+    private static final String WEBHOOK_URL = "https://webhook.site";   // default
+    private static final String REQUEST_BIN_URL = "https://requestbin.io";
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestBinFactoryImpl.class);
+
+    @Override
+    public RequestBin create() throws IOException, NotImplementedException {
+        String source = System.getenv("REQUEST_BIN_URL");
+        if(source == null) {
+            source = WEBHOOK_URL;
+        }
+
+        if(source.equals(REQUEST_BIN_URL)) {
+            return new RBImplRequestBin();
+        } else if(source.equals(WEBHOOK_URL)) {
+            return new RBImplWebHook();
+        }
+
+        LOGGER.warn(String.format("For given source: %s, does not exist implementation. Returning null", source));
+        return null;
+    }
+}

--- a/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinResult.java
+++ b/src/test/java/io/patriot_framework/network_simulator/kubernetes/utils/request_bin/RequestBinResult.java
@@ -1,4 +1,4 @@
-package io.patriot_framework.network_simulator.kubernetes.utils;
+package io.patriot_framework.network_simulator.kubernetes.utils.request_bin;
 
 /**
  * Represents once object retrieved from request bin.


### PR DESCRIPTION
This PR includes:

- bump project version to 5.0.0-SNAPSHOT,
- bump Java version from 8 to 17,
- bump dependencies with vulnerabilities,
- update KubernetesControllerTest, so it uses new web api - previously used web api doesn't work anymore. 